### PR TITLE
x_type vars use mix of 'hash' and 'dict'

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -225,7 +225,7 @@ define launchd::job (
         }
 
         if is_hash($start_calendar_interval) {
-            $start_calendar_interval_type = 'hash'
+            $start_calendar_interval_type = 'dict'
         } elsif is_array($start_calendar_interval) {
             $start_calendar_interval_type = 'array'
         } else {
@@ -247,10 +247,10 @@ define launchd::job (
 
     if $keep_alive != undef {
         if is_hash($keep_alive) == false and is_bool($keep_alive) == false {
-            fail("keep_alive must be an array or bool.")
+            fail("keep_alive must be a hash or bool.")
         }
         if is_hash($keep_alive) {
-            $keep_alive_type = 'hash'
+            $keep_alive_type = 'dict'
         } elsif is_bool($keep_alive) {
             $keep_alive_type = 'bool'
         }


### PR DESCRIPTION
manifest/job.pp and templates/launchd_plist.erb disagreed
on the name of the type for hash/dict and this was breaking
start_calendar_interval and keep_alive. Normalized to
'dict'. Also fixed an incorrect error message about types.